### PR TITLE
Use logger + prevent legacy material usage

### DIFF
--- a/src/main/java/com/darkzek/autoreload/AutoReload.java
+++ b/src/main/java/com/darkzek/autoreload/AutoReload.java
@@ -96,7 +96,7 @@ public class AutoReload extends JavaPlugin {
 
         for (int i = 0; i < listOfFiles.length; i++) {
             if (listOfFiles[i].isFile() && listOfFiles[i].getName().endsWith(".jar")) {
-                System.out.println("Found plugin " + listOfFiles[i].getName());
+                getLogger().log(Level.INFO, "Found plugin " + listOfFiles[i].getName());
                 timeSinceLastChanged.put(listOfFiles[i].getName(), listOfFiles[i].lastModified());
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: AutoReload
 main: com.darkzek.autoreload.AutoReload
 version: 1.03
+api-version: 1.13
 author: DarkZek
 commands:


### PR DESCRIPTION
Don't know if this plugin is still maintained but these are two small QOL fixes for a small and useful plugin